### PR TITLE
HCSVLAB-998: add authorisation to create collection api call

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -4,6 +4,8 @@ require 'fileutils'
 class CollectionsController < ApplicationController
   before_filter :authenticate_user!
   #load_and_authorize_resource
+  load_resource :only => [:create]
+  skip_authorize_resource :only => [:create] # authorise create method with custom permission denied error
 
   set_tab :collection
 
@@ -43,6 +45,8 @@ class CollectionsController < ApplicationController
   end
 
   def create
+    authorize! :create, @collection,
+               :message => "Permission Denied: Your role within the system does not have sufficient privileges to be able to create a collection. Please contact an Alveo administrator."
     if request.format == 'json' and request.post?
       collection_name = params[:name]
       if !collection_name.nil? and !collection_name.blank? and !(collection_name.length > 255) and !(params[:collection_metadata].nil?)
@@ -154,13 +158,13 @@ class CollectionsController < ApplicationController
 
   # Coverts JSON-LD formatted collection metadata and converts it to RDF
   def convert_json_metadata_to_rdf(json_metadata)
-    graph = RDF::Graph.new << JSON::LD::API.toRdf(json_metadata)
+    graph = RDF::Graph.new << JSON::LD::API.toRDF(json_metadata)
     graph.dump(:ttl, prefixes: {foaf: "http://xmlns.com/foaf/0.1/"})
   end
 
   # Gets the collection URI from JSON-LD formatted metadata
   def get_uri_from_metadata(json_metadata)
-    graph = RDF::Graph.new << JSON::LD::API.toRdf(json_metadata)
+    graph = RDF::Graph.new << JSON::LD::API.toRDF(json_metadata)
     graph.statements.first.subject.to_s
   end
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -102,6 +102,13 @@ class Ability
     #      ((user.groups & aCollection.edit_groups).length > 0)
     #end
 
+    if is_data_owner or is_superuser
+      can :create, Collection
+    else if is_researcher
+        cannot :create, Collection
+      end
+    end
+
     ############################################################
     ##          PERMISSIONS OVER COLLECTION LIST              ##
     ############################################################

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -104,9 +104,8 @@ class Ability
 
     if is_data_owner or is_superuser
       can :create, Collection
-    else if is_researcher
-        cannot :create, Collection
-      end
+    else
+      cannot :create, Collection
     end
 
     ############################################################

--- a/config/initializers/error_response_actions.rb
+++ b/config/initializers/error_response_actions.rb
@@ -17,7 +17,7 @@ module ErrorResponseActions
         redirect_to root_url
       }
       format.xml { render :xml => exception.message, :status => 403 }
-      format.any { render :json => exception.message, :status => 403 }
+      format.any { render :json => {:error => exception.message}.to_json, :status => 403 }
     end
   end
 

--- a/features/api.feature
+++ b/features/api.feature
@@ -6,9 +6,13 @@ Feature: Browsing via API
     Given I have the usual roles and permissions
     And I have users
       | email                        | first_name | last_name |
+      | admin@intersect.org.au       | Admin      | One       |
       | researcher1@intersect.org.au | Researcher | One       |
       | data_owner@intersect.org.au  | Data_Owner | One       |
+    And "admin@intersect.org.au" has role "admin"
+    And "admin@intersect.org.au" has an api token
     And "data_owner@intersect.org.au" has role "data owner"
+    And "data_owner@intersect.org.au" has an api token
     And "researcher1@intersect.org.au" has role "researcher"
     And "researcher1@intersect.org.au" has an api token
     And "researcher1@intersect.org.au" has item lists
@@ -1393,8 +1397,28 @@ Feature: Browsing via API
     {"success":"0 cleared from item list Test 1"}
     """
 
-  Scenario: Create new collection via the API
+  Scenario: Create new collection via the API as a researcher
     Given I make a JSON post request for the collections page with the API token for "researcher1@intersect.org.au" with JSON params
+      | name | collection_metadata |
+      | Test | {"@context": {"TEST": "http://collection.test", "dc": "http://purl.org/dc/elements/1.1/", "dcmitype": "http://purl.org/dc/dcmitype/", "marcrel": "http://www.loc.gov/loc.terms/relators/", "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#", "rdfs": "http://www.w3.org/2000/01/rdf-schema#", "xsd": "http://www.w3.org/2001/XMLSchema#" }, "@id": "http://collection.test", "@type": "dcmitype:Collection", "dc:creator": "Pam Peters", "dc:rights": "All rights reserved to Data Owner", "dc:subject": "English Language", "dc:title": "A test collection", "marcrel:OWN": "Data Owner"} |
+    Then I should get a 403 response code
+    And the JSON response should be:
+    """
+    {"error":"Permission Denied: Your role within the system does not have sufficient privileges to be able to create a collection. Please contact an Alveo administrator."}
+    """
+
+  Scenario: Create new collection via the API as a data owner
+    Given I make a JSON post request for the collections page with the API token for "data_owner@intersect.org.au" with JSON params
+      | name | collection_metadata |
+      | Test | {"@context": {"TEST": "http://collection.test", "dc": "http://purl.org/dc/elements/1.1/", "dcmitype": "http://purl.org/dc/dcmitype/", "marcrel": "http://www.loc.gov/loc.terms/relators/", "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#", "rdfs": "http://www.w3.org/2000/01/rdf-schema#", "xsd": "http://www.w3.org/2001/XMLSchema#" }, "@id": "http://collection.test", "@type": "dcmitype:Collection", "dc:creator": "Pam Peters", "dc:rights": "All rights reserved to Data Owner", "dc:subject": "English Language", "dc:title": "A test collection", "marcrel:OWN": "Data Owner"} |
+    Then I should get a 200 response code
+    And the JSON response should be:
+    """
+    {"success":"Request for new collection 'Test' (http://collection.test) sent to Administrator"}
+    """
+
+  Scenario: Create new collection via the API as an admin
+    Given I make a JSON post request for the collections page with the API token for "admin@intersect.org.au" with JSON params
       | name | collection_metadata |
       | Test | {"@context": {"TEST": "http://collection.test", "dc": "http://purl.org/dc/elements/1.1/", "dcmitype": "http://purl.org/dc/dcmitype/", "marcrel": "http://www.loc.gov/loc.terms/relators/", "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#", "rdfs": "http://www.w3.org/2000/01/rdf-schema#", "xsd": "http://www.w3.org/2001/XMLSchema#" }, "@id": "http://collection.test", "@type": "dcmitype:Collection", "dc:creator": "Pam Peters", "dc:rights": "All rights reserved to Data Owner", "dc:subject": "English Language", "dc:title": "A test collection", "marcrel:OWN": "Data Owner"} |
     Then I should get a 200 response code
@@ -1404,10 +1428,10 @@ Feature: Browsing via API
     """
 
   Scenario: Create new collection via the API with duplicate name
-    Given I make a JSON post request for the collections page with the API token for "researcher1@intersect.org.au" with JSON params
+    Given I make a JSON post request for the collections page with the API token for "data_owner@intersect.org.au" with JSON params
       | name | collection_metadata |
       | Test | {"@context": {"TEST": "http://collection.test", "dc": "http://purl.org/dc/elements/1.1/", "dcmitype": "http://purl.org/dc/dcmitype/", "marcrel": "http://www.loc.gov/loc.terms/relators/", "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#", "rdfs": "http://www.w3.org/2000/01/rdf-schema#", "xsd": "http://www.w3.org/2001/XMLSchema#" }, "@id": "http://collection.test", "@type": "dcmitype:Collection", "dc:creator": "Pam Peters", "dc:rights": "All rights reserved to Data Owner", "dc:subject": "English Language", "dc:title": "A test collection", "marcrel:OWN": "Data Owner"} |
-    Given I make a JSON post request for the collections page with the API token for "researcher1@intersect.org.au" with JSON params
+    Given I make a JSON post request for the collections page with the API token for "data_owner@intersect.org.au" with JSON params
       | name | collection_metadata |
       | Test | {"@context": {"TEST": "http://other.collection/test", "dc": "http://purl.org/dc/elements/1.1/", "dcmitype": "http://purl.org/dc/dcmitype/", "marcrel": "http://www.loc.gov/loc.terms/relators/", "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#", "rdfs": "http://www.w3.org/2000/01/rdf-schema#", "xsd": "http://www.w3.org/2001/XMLSchema#" }, "@id": "http://other.collection/test", "@type": "dcmitype:Collection", "dc:creator": "Pam Peters", "dc:rights": "All rights reserved to Data Owner", "dc:subject": "English Language", "dc:title": "Another test collection", "marcrel:OWN": "Data Owner"} |
     Then I should get a 200 response code
@@ -1417,10 +1441,10 @@ Feature: Browsing via API
     """
 
   Scenario: Create new collection via the API with duplicate uri
-    Given I make a JSON post request for the collections page with the API token for "researcher1@intersect.org.au" with JSON params
+    Given I make a JSON post request for the collections page with the API token for "data_owner@intersect.org.au" with JSON params
       | name | collection_metadata |
       | Test | {"@context": {"TEST": "http://collection.test", "dc": "http://purl.org/dc/elements/1.1/", "dcmitype": "http://purl.org/dc/dcmitype/", "marcrel": "http://www.loc.gov/loc.terms/relators/", "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#", "rdfs": "http://www.w3.org/2000/01/rdf-schema#", "xsd": "http://www.w3.org/2001/XMLSchema#" }, "@id": "http://collection.test", "@type": "dcmitype:Collection", "dc:creator": "Pam Peters", "dc:rights": "All rights reserved to Data Owner", "dc:subject": "English Language", "dc:title": "A test collection", "marcrel:OWN": "Data Owner"} |
-    Given I make a JSON post request for the collections page with the API token for "researcher1@intersect.org.au" with JSON params
+    Given I make a JSON post request for the collections page with the API token for "data_owner@intersect.org.au" with JSON params
       | name         | collection_metadata |
       | Another Test | {"@context": {"TEST": "http://collection.test", "dc": "http://purl.org/dc/elements/1.1/", "dcmitype": "http://purl.org/dc/dcmitype/", "marcrel": "http://www.loc.gov/loc.terms/relators/", "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#", "rdfs": "http://www.w3.org/2000/01/rdf-schema#", "xsd": "http://www.w3.org/2001/XMLSchema#" }, "@id": "http://collection.test", "@type": "dcmitype:Collection", "dc:creator": "Pam Peters", "dc:rights": "All rights reserved to Data Owner", "dc:subject": "English Language", "dc:title": "Another test collection", "marcrel:OWN": "Data Owner"} |
     Then I should get a 400 response code
@@ -1430,7 +1454,7 @@ Feature: Browsing via API
     """
 
   Scenario: Create new collection via the API without JSON params
-    Given I make a JSON post request for the collections page with the API token for "researcher1@intersect.org.au" without JSON params
+    Given I make a JSON post request for the collections page with the API token for "data_owner@intersect.org.au" without JSON params
     Then I should get a 400 response code
     And the JSON response should be:
     """
@@ -1438,7 +1462,7 @@ Feature: Browsing via API
     """
 
   Scenario: Create new collection via the API without name param
-    Given I make a JSON post request for the collections page with the API token for "researcher1@intersect.org.au" with JSON params
+    Given I make a JSON post request for the collections page with the API token for "data_owner@intersect.org.au" with JSON params
       | collection_metadata |
       | {"@context": {"TEST": "http://collection.test", "dc": "http://purl.org/dc/elements/1.1/", "dcmitype": "http://purl.org/dc/dcmitype/", "marcrel": "http://www.loc.gov/loc.terms/relators/", "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#", "rdfs": "http://www.w3.org/2000/01/rdf-schema#", "xsd": "http://www.w3.org/2001/XMLSchema#" }, "@id": "http://collection.test", "@type": "dcmitype:Collection", "dc:creator": "Pam Peters", "dc:rights": "All rights reserved to Data Owner", "dc:subject": "English Language", "dc:title": "A test collection", "marcrel:OWN": "Data Owner"} |
     Then I should get a 400 response code
@@ -1448,7 +1472,7 @@ Feature: Browsing via API
     """
 
   Scenario: Create new collection via the API without the metadata param
-    Given I make a JSON post request for the collections page with the API token for "researcher1@intersect.org.au" with JSON params
+    Given I make a JSON post request for the collections page with the API token for "data_owner@intersect.org.au" with JSON params
       | name |
       | Test |
     Then I should get a 400 response code


### PR DESCRIPTION
Add authorisation to the create collection method.
- Users with role 'admin' and 'data owner' are authorised while 'researcher' is unauthorised.
- Return custom permission denied error as JSON if user is unauthorised.