### PR TITLE
HCSVLAB-996: update create collection to work with current gemset

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -154,13 +154,13 @@ class CollectionsController < ApplicationController
 
   # Coverts JSON-LD formatted collection metadata and converts it to RDF
   def convert_json_metadata_to_rdf(json_metadata)
-    graph = RDF::Graph.new << JSON::LD::API.toRdf(json_metadata)
+    graph = RDF::Graph.new << JSON::LD::API.toRDF(json_metadata)
     graph.dump(:ttl, prefixes: {foaf: "http://xmlns.com/foaf/0.1/"})
   end
 
   # Gets the collection URI from JSON-LD formatted metadata
   def get_uri_from_metadata(json_metadata)
-    graph = RDF::Graph.new << JSON::LD::API.toRdf(json_metadata)
+    graph = RDF::Graph.new << JSON::LD::API.toRDF(json_metadata)
     graph.statements.first.subject.to_s
   end
 


### PR DESCRIPTION
Prior create collection api implementation assumed installation of ruby gem json-ld v1.1.9 and its dependencies, which caused some existing api tests to fail.
Implementation has been updated to maintain compatibility with the current set of gems, to avoid failure of other api tests.