### PR TITLE
HCSVLAB-1020: fix issue with deleting from solr

### DIFF
--- a/lib/tasks/fedora_helper.rb
+++ b/lib/tasks/fedora_helper.rb
@@ -90,7 +90,7 @@ def deindex_item_from_solr(item_id, stomp_client)
   if Rails.env.test?
     Solr_Worker.new.on_message("delete #{item_id}")
   else
-    stomp_client.publish('alveo.solr.worker.dlq', "delete #{item_id}")
+    stomp_client.publish('alveo.solr.worker', "delete #{item_id}")
   end
 end
 


### PR DESCRIPTION
The delete item index from Solr was mistakenly being published to the Solr worker dead letter queue, rather than the Solr worker. This resulted in the item index not being deleted from Solr and the item still being viewable via the collection faceted search after deleting.