### PR TITLE
HCSVLAB-1020: add stomp client fix for jenkins build

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -395,7 +395,7 @@ class CollectionsController < ApplicationController
   def remove_item(item, collection, corpus_dir)
     delete_item_from_filesystem(item, corpus_dir)
     delete_from_sesame(item, collection)
-    delete_from_solr(item)
+    delete_item_from_solr(item.id)
     item.destroy # Remove from database (item, its documents and their document audits)
   end
 
@@ -416,13 +416,6 @@ class CollectionsController < ApplicationController
     item.documents.each do |document|
       delete_document_from_sesame(document, repository)
     end
-  end
-
-  # Deletes an items index from Solr
-  def delete_from_solr(item)
-    stomp_client = Stomp::Client.open "stomp://localhost:61613"
-    deindex_item_from_solr(item.id, stomp_client)
-    stomp_client.close
   end
 
   # Attempts to delete a file or logs any exceptions raised

--- a/lib/tasks/fedora_helper.rb
+++ b/lib/tasks/fedora_helper.rb
@@ -85,12 +85,15 @@ def reindex_item_to_solr(item_id, stomp_client)
   stomp_client.publish('/queue/alveo.solr.worker', "index #{item_id}")
 end
 
-def deindex_item_from_solr(item_id, stomp_client)
+def delete_item_from_solr(item_id)
   logger.info "Deindexing item: #{item_id}"
+  #ToDo: refactor this workaround into a proper test mock/stub
   if Rails.env.test?
     Solr_Worker.new.on_message("delete #{item_id}")
   else
+    stomp_client = Stomp::Client.open "stomp://localhost:61613"
     stomp_client.publish('alveo.solr.worker', "delete #{item_id}")
+    stomp_client.close
   end
 end
 


### PR DESCRIPTION
Should provide a fix for the following Jenkins build error:
Connection refused - connect(2) for "localhost" port 61613 (Errno::ECONNREFUSED)
/var/lib/jenkins/.rvm/rubies/ruby-2.1.4/lib/ruby/2.1.0/timeout.rb:76:in `timeout'
./app/controllers/collections_controller.rb:436:in `delete_from_solr'
./app/controllers/collections_controller.rb:411:in `remove_item'
./app/controllers/collections_controller.rb:152:in `delete_item_from_collection'
features/api.feature:1881:in `When I make a JSON delete request for the delete item "item1" from collection "Test" page with the API token for "data_owner@intersect.org.au"'

Failing Scenarios:
cucumber features/api.feature:1871 # Scenario: Delete an item as the collection owner