### PR TITLE
HCSVLAB-1123: update delete document for existing collections

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -563,21 +563,45 @@ class CollectionsController < ApplicationController
     end
   end
 
+  #
+  # Gets the document URI from Sesame
+  # URI is obtained by querying the item's RDF documents for a doc with a metadata ID matching the doc filename in the db
+  #
+  def get_doc_subject_uri_from_sesame(document, repository)
+    document_uri = nil
+    item_documents = RDF::Query.execute(repository) do
+      pattern [RDF::URI.new(document.item.uri), MetadataHelper::DOCUMENT, :object]
+    end
+    item_documents.each do |doc|
+      doc_ids = RDF::Query.execute(repository) do
+        pattern [doc[:object], MetadataHelper::IDENTIFIER, :doc_id]
+      end
+      doc_ids.each do |doc_id|
+        if doc_id[:doc_id] == document.file_name
+          document_uri = doc[:object]
+        end
+      end
+    end
+    raise 'Could not obtain document URI from Sesame' if document_uri.nil?
+    document_uri
+  end
+
+  #
   # Deletes statements from Sesame where the RDF subject matches the document URI
+  #
   def delete_document_from_sesame(document, repository)
-    item_name = document.item.handle.split(":")[1]
-    document_URI = RDF::URI.new(format_document_url(document.item.collection.name, item_name, document.file_name))
+    document_uri = get_doc_subject_uri_from_sesame(document, repository)
     triples_with_doc_subject = RDF::Query.execute(repository) do
-      pattern [document_URI, :predicate, :object]
+      pattern [document_uri, :predicate, :object]
     end
     triples_with_doc_subject.each do |statement|
-      repository.delete(RDF::Statement(document_URI, statement[:predicate], statement[:object]))
+      repository.delete(RDF::Statement(document_uri, statement[:predicate], statement[:object]))
     end
     triples_with_doc_object = RDF::Query.execute(repository) do
-      pattern [:subject, :predicate, document_URI]
+      pattern [:subject, :predicate, document_uri]
     end
     triples_with_doc_object.each do |statement|
-      repository.delete(RDF::Statement(statement[:subject], statement[:predicate], document_URI))
+      repository.delete(RDF::Statement(statement[:subject], statement[:predicate], document_uri))
     end
   end
 
@@ -609,10 +633,10 @@ class CollectionsController < ApplicationController
   # Deletes an item and its documents from Sesame
   def delete_from_sesame(item, collection)
     repository = get_sesame_repository(collection)
-    delete_item_from_sesame(item, repository)
     item.documents.each do |document|
       delete_document_from_sesame(document, repository)
     end
+    delete_item_from_sesame(item, repository)
   end
 
   # Attempts to delete a file or logs any exceptions raised

--- a/features/delete_document.feature
+++ b/features/delete_document.feature
@@ -61,22 +61,32 @@ Feature: Deleting Documents
     When I click the delete icon for document "1-001-plain.txt" of item "cooee:1-001"
     Then The popup text should contain "Are you sure you want to delete this document?"
 
-## ToDo: include this test if it can be resolved why api uses host http://example.org and web interface uses host http://www.example.com
-#  @web_delete_document
-#  Scenario: Delete a document as the item owner (API ingested collection)
-#    Given I make a JSON post request for the collections page with the API token for "data_owner@intersect.org.au" with JSON params
-#      | name | collection_metadata |
-#      | Test | {"@context": {"Test": "http://collection.test", "dc": "http://purl.org/dc/elements/1.1/", "dcmitype": "http://purl.org/dc/dcmitype/", "marcrel": "http://www.loc.gov/loc.terms/relators/", "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#", "rdfs": "http://www.w3.org/2000/01/rdf-schema#", "xsd": "http://www.w3.org/2001/XMLSchema#" }, "@id": "http://collection.test", "@type": "dcmitype:Collection", "dc:creator": "Pam Peters", "dc:rights": "All rights reserved to Data Owner", "dc:subject": "English Language", "dc:title": "A test collection", "marcrel:OWN": "Data Owner"} |
-#    And I make a JSON post request for the collection page for id "Test" with the API token for "data_owner@intersect.org.au" with JSON params
-#      | items |
-#      | [ { "documents": [ { "identifier": "document1.txt", "content": "This document had its content provided as part of the JSON request." } ], "metadata": { "@context": { "ausnc": "http://ns.ausnc.org.au/schemas/ausnc_md_model/", "corpus": "http://ns.ausnc.org.au/corpora/", "dc": "http://purl.org/dc/terms/", "dcterms": "http://purl.org/dc/terms/", "foaf": "http://xmlns.com/foaf/0.1/", "hcsvlab": "http://hcsvlab.org/vocabulary/", "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#", "rdfs": "http://www.w3.org/2000/01/rdf-schema#", "xsd": "http://www.w3.org/2001/XMLSchema#" }, "@graph": [ { "@id": "item1", "@type": "ausnc:AusNCObject", "ausnc:document": [ { "@id": "document1.txt", "@type": "foaf:Document", "dcterms:identifier": "document1.txt", "dcterms:title": "document1#Text", "dcterms:type": "Text" } ], "dcterms:identifier": "item1", "hcsvlab:display_document": { "@id": "document1.txt" }, "hcsvlab:indexable_document": { "@id": "document1.txt" } } ] } } ] |
-#    And I reindex the collection "Test"
-#    And I am logged in as "data_owner@intersect.org.au"
-#    When I go to the delete document web path for "document1.txt" in "Test:item1"
-#    Then I should be on the catalog page for "Test:item1"
-#    And the document "document1.txt" under item "item1" in collection "Test" should not exist in the database
-#    And the file "document1.txt" should not exist in the directory for the collection "Test"
-#    And Sesame should not contain a document with file_name "document1.txt" in collection "Test"
-#    And I should not see link "Closebox" to "/catalog/Test/item1/document/document1.txt/delete"
-#    And I should not see "document1.txt Text "
+  @web_delete_document
+  Scenario: Delete a document as the item owner (API ingested collection)
+    Given I make a JSON post request for the collections page with the API token for "data_owner@intersect.org.au" with JSON params
+      | name | collection_metadata |
+      | Test | {"@context": {"Test": "http://collection.test", "dc": "http://purl.org/dc/elements/1.1/", "dcmitype": "http://purl.org/dc/dcmitype/", "marcrel": "http://www.loc.gov/loc.terms/relators/", "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#", "rdfs": "http://www.w3.org/2000/01/rdf-schema#", "xsd": "http://www.w3.org/2001/XMLSchema#" }, "@id": "http://collection.test", "@type": "dcmitype:Collection", "dc:creator": "Pam Peters", "dc:rights": "All rights reserved to Data Owner", "dc:subject": "English Language", "dc:title": "A test collection", "marcrel:OWN": "Data Owner"} |
+    And I make a JSON post request for the collection page for id "Test" with the API token for "data_owner@intersect.org.au" with JSON params
+      | items |
+      | [ { "documents": [ { "identifier": "document1.txt", "content": "This document had its content provided as part of the JSON request." } ], "metadata": { "@context": { "ausnc": "http://ns.ausnc.org.au/schemas/ausnc_md_model/", "corpus": "http://ns.ausnc.org.au/corpora/", "dc": "http://purl.org/dc/terms/", "dcterms": "http://purl.org/dc/terms/", "foaf": "http://xmlns.com/foaf/0.1/", "hcsvlab": "http://hcsvlab.org/vocabulary/", "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#", "rdfs": "http://www.w3.org/2000/01/rdf-schema#", "xsd": "http://www.w3.org/2001/XMLSchema#" }, "@graph": [ { "@id": "item1", "@type": "ausnc:AusNCObject", "ausnc:document": [ { "@id": "document1.txt", "@type": "foaf:Document", "dcterms:identifier": "document1.txt", "dcterms:title": "document1#Text", "dcterms:type": "Text" } ], "dcterms:identifier": "item1", "hcsvlab:display_document": { "@id": "document1.txt" }, "hcsvlab:indexable_document": { "@id": "document1.txt" } } ] } } ] |
+    And I reindex the collection "Test"
+    And I am logged in as "data_owner@intersect.org.au"
+    When I go to the delete document web path for "document1.txt" in "Test:item1"
+    Then I should be on the catalog page for "Test:item1"
+    And the document "document1.txt" under item "item1" in collection "Test" should not exist in the database
+    And the file "document1.txt" should not exist in the directory for the collection "Test"
+    And Sesame should not contain a document with file_name "document1.txt" in collection "Test"
+    And I should not see link "Closebox" to "/catalog/Test/item1/document/document1.txt/delete"
+    And I should not see "document1.txt Text "
 
+  @web_delete_document
+  Scenario: Delete a document as the item owner (manual ingested collection)
+    Given I ingest "cooee:1-001"
+    And I am logged in as "data_owner@intersect.org.au"
+    When I go to the delete document web path for "1-001-plain.txt" in "cooee:1-001"
+    Then I should be on the catalog page for "cooee:1-001"
+    And the document "1-001-plain.txt" under item "1-001" in collection "cooee" should not exist in the database
+    And the file "1-001-plain.txt" should not exist in the directory for the collection "cooee"
+    And Sesame should not contain a document with file_name "1-001-plain.txt" in collection "cooee"
+    And I should not see link "Closebox" to "/catalog/cooee/1-001/document/1-001-plain.txt/delete"
+    And I should not see "1-001-plain.txt Text "


### PR DESCRIPTION
Update delete document so that it is able to delete documents from Sesame, where the document belongs to manually ingested collections.