### PR TITLE
HCSVLAB-1120: repopulate form fields on validation failure

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -138,7 +138,7 @@ class CollectionsController < ApplicationController
     @collection_abstract = params[:collection_abstract]
     @licence_id = params[:licence_id]
     @additional_metadata = []
-    unless params[:additional_key].nil? || params[:additional_key].nil?
+    unless params[:additional_key].nil? || params[:additional_value].nil?
       @additional_metadata = params[:additional_key].zip(params[:additional_value])
     end
     if request.post?

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -132,6 +132,15 @@ class CollectionsController < ApplicationController
     # Expose public licences and user created licences
     licence_table = Licence.arel_table
     @licences = Licence.where(licence_table[:private].eq(false).or(licence_table[:owner_id].eq(current_user.id)))
+    @collection_name = params[:collection_name]
+    @collection_title = params[:collection_title]
+    @collection_owner = params[:collection_owner]
+    @collection_abstract = params[:collection_abstract]
+    @licence_id = params[:licence_id]
+    @additional_metadata = []
+    unless params[:additional_key].nil? || params[:additional_key].nil?
+      @additional_metadata = params[:additional_key].zip(params[:additional_value])
+    end
     if request.post?
       begin
         # Check required fields

--- a/app/views/collections/web_create_collection.haml
+++ b/app/views/collections/web_create_collection.haml
@@ -1,18 +1,21 @@
 %h2 Create Collection
 = form_tag({controller: 'collections', action: 'web_create_collection'}, method: 'post', :id => 'create_collection_form') do
   = label_tag :collection_name, 'Collection Name:'
-  = text_field_tag :collection_name, nil, required: true
+  = text_field_tag :collection_name, @collection_name, required: true
   = label_tag :collection_title, 'Collection Title:'
-  = text_field_tag :collection_title, nil, required: true
+  = text_field_tag :collection_title, @collection_title, required: true
   = label_tag :collection_owner, 'Collection Owner:'
-  = text_field_tag :collection_owner, nil, required: true
+  = text_field_tag :collection_owner, @collection_owner, required: true
   = label_tag :collection_abstract, 'Collection Abstract:'
-  = text_area_tag :collection_abstract, nil, required: true
+  = text_area_tag :collection_abstract, @collection_abstract, required: true
   = label_tag :licence_id, 'Licence'
   = select_tag :licence_id, options_for_select(@licences.map {|l| [l.name, l.id]}), include_blank: true
 
   %h2 Additional Metadata
-  See #{link_to 'searchable fields', catalog_searchable_fields_path} for suggestions
+  See the RDF Names of #{link_to 'searchable fields', catalog_searchable_fields_path, target: :_blank} for examples of accepted metadata field names.
+  %br
+  Note: If the context for a field you want to enter is not available in the
+  #{link_to 'default schema', annotation_context_path, target: :_blank} then you must provide the full URI for that metadata field.
 
   #additional_metadata
 
@@ -22,12 +25,19 @@
     = link_to 'Cancel', collections_path
     = submit_tag 'Create'
 
-
 = render 'shared/nectar_attribution'
 
 :javascript
-  $("#add_metadata_btn").click(function(){
-    var key_field = "<label>Key:</label><input type='text' name='additional_key[]' class='metadata_field'/>";
-    var value_field = "<label>Value:</label><input type='text' name='additional_value[]' class='metadata_field'/>";
+  function add_metadata_field(meta_key, meta_value) {
+    var key_field = "<label>Name:</label><input type='text' name='additional_key[]' class='metadata_field' value='"+meta_key+"'/>";
+    var value_field = "<label>Value:</label><input type='text' name='additional_value[]' class='metadata_field' value='"+meta_value+"'/>";
     $("#additional_metadata").append("<br><div class='metadata_pair'>"+key_field+value_field+"</div>");
+  }
+
+  $("#add_metadata_btn").click(function() {
+    add_metadata_field('', '');
   });
+
+- @additional_metadata.each do |meta_key, meta_value|
+  - unless meta_key.blank? && meta_value.blank?
+    = javascript_tag "add_metadata_field('#{meta_key}', '#{meta_value}')"

--- a/features/collections_create.feature
+++ b/features/collections_create.feature
@@ -43,26 +43,27 @@ Feature: Creating Collections
     And I should see "Collection Owner:"
     And I should see "Collection Abstract"
     And I should see "Additional Metadata"
-    And I should see "See searchable fields for suggestions"
+    And I should see "See the RDF Names of searchable fields for examples of accepted metadata field names."
     And I should see link "searchable fields" to "/catalog/searchable_fields"
+    And I should see "Note: If the context for a field you want to enter is not available in the default schema then you must provide the full URI for that metadata field."
+    And I should see link "default schema" to "/schema/json-ld"
     And I should see "Add Metadata Field"
     And I should see button with text "Add Metadata Field"
     And I should see link "Cancel" to "/catalog"
     And I should see "Create"
     And I should see button "Create"
 
-  Scenario: Verify add metadata key/value fields not visible by default
+  Scenario: Verify add metadata name/value fields not visible by default
     Given I am logged in as "data_owner@intersect.org.au"
     When I am on the create collection page
-    Then I should not see "Key:"
-    And I should not see "Value:"
+    Then I should not see "Name: Value: "
 
   @javascript
-  Scenario: Verify add metadata key/value fields visible after clicking add metadata field button
+  Scenario: Verify add metadata name/value fields visible after clicking add metadata field button
     Given I am logged in as "data_owner@intersect.org.au"
     And I am on the create collection page
     When I click "Add Metadata Field"
-    Then I should see "Key:"
+    Then I should see "Name:"
     And I should see "Value:"
 
   @create_collection
@@ -164,6 +165,27 @@ Feature: Creating Collections
     | key | value | response|
     |     | bar   | An additional metadata field is missing a key      |
     | foo |       | Additional metadata field 'foo' is missing a value |
+
+  @create_collection @javascript
+  Scenario: Verify form is re-populated with previous input if an error occurs
+    Given I am logged in as "data_owner@intersect.org.au"
+    And I am on the create collection page
+    And I click "Add Metadata Field"
+    When I fill in "collection_name" with "test"
+    And I fill in "collection_title" with "Test Title"
+    And I fill in "collection_owner" with "Test Owner"
+    And I fill in "collection_abstract" with "Test Abstract"
+    And I fill in "additional_key[]" with "foo"
+    And I fill in "additional_value[]" with ""
+    And I press "Create"
+    Then I should be on the create collection page
+    And I should see " Additional metadata field 'foo' is missing a value"
+    And the "collection_name" field should contain "test"
+    And the "collection_title" field should contain "Test Title"
+    And the "collection_owner" field should contain "Test Owner"
+    And the "collection_abstract" field should contain "Test Abstract"
+    And the "additional_key[]" field should contain "foo"
+    And the "additional_value[]" field should contain ""
 
   @create_collection
   Scenario: Verify the collection name needs to be unique within the system


### PR DESCRIPTION
Repopulate form fields with previous input when validation failure occurs. Also open link to searchable fields in new tab.