### PR TITLE
HCSVLAB-1121: repopulate form fields on validation failure

### DIFF
--- a/app/views/collections/_display_additional_metadata.html.haml
+++ b/app/views/collections/_display_additional_metadata.html.haml
@@ -1,5 +1,8 @@
 %h2 Additional Metadata
-See #{link_to 'searchable fields', catalog_searchable_fields_path} for suggestions
+See the RDF Names of #{link_to 'searchable fields', catalog_searchable_fields_path, target: :_blank} for examples of accepted metadata field names.
+%br
+Note: If the context for a field you want to enter is not available in the
+#{link_to 'default schema', annotation_context_path, target: :_blank} then you must provide the full URI for that metadata field.
 
 #additional_metadata
 
@@ -8,8 +11,16 @@ See #{link_to 'searchable fields', catalog_searchable_fields_path} for suggestio
   = button_tag 'Add Metadata Field', :id =>'add_metadata_btn', type: 'button'
 
 :javascript
-  $("#add_metadata_btn").click(function(){
-    var key_field = "<label>Key:</label><input type='text' name='additional_key[]' class='metadata_field'/>";
-    var value_field = "<label>Value:</label><input type='text' name='additional_value[]' class='metadata_field'/>";
+  function add_metadata_field(meta_key, meta_value) {
+    var key_field = "<label>Name:</label><input type='text' name='additional_key[]' class='metadata_field' value='"+meta_key+"'/>";
+    var value_field = "<label>Value:</label><input type='text' name='additional_value[]' class='metadata_field' value='"+meta_value+"'/>";
     $("#additional_metadata").append("<br><div class='metadata_pair'>"+key_field+value_field+"</div>");
+  }
+
+  $("#add_metadata_btn").click(function() {
+    add_metadata_field('', '');
   });
+
+- @additional_metadata.each do |meta_key, meta_value|
+  - unless meta_key.blank? && meta_value.blank?
+    = javascript_tag "add_metadata_field('#{meta_key}', '#{meta_value}')"

--- a/app/views/collections/web_add_item.html.haml
+++ b/app/views/collections/web_add_item.html.haml
@@ -1,10 +1,11 @@
 %h2 Create Item
 = form_tag({controller: 'collections', action: 'web_add_item'}, method: 'post', :id => 'add_item_form') do
   = label_tag :item_name, 'Item Name:'
-  = text_field_tag :item_name, nil, required: true
+  = text_field_tag :item_name, @item_name, required: true
   = label_tag :item_title, 'Item Title:'
-  = text_field_tag :item_title, nil, required: true
+  = text_field_tag :item_title, @item_title, required: true
   = render 'display_additional_metadata'
+
   %br
   = link_to 'Cancel', collection_path(id: params[:id])
   = submit_tag 'Create'

--- a/app/views/collections/web_create_collection.haml
+++ b/app/views/collections/web_create_collection.haml
@@ -10,34 +10,10 @@
   = text_area_tag :collection_abstract, @collection_abstract, required: true
   = label_tag :licence_id, 'Licence'
   = select_tag :licence_id, options_for_select(@licences.map {|l| [l.name, l.id]}), include_blank: true
+  = render 'display_additional_metadata'
 
-  %h2 Additional Metadata
-  See the RDF Names of #{link_to 'searchable fields', catalog_searchable_fields_path, target: :_blank} for examples of accepted metadata field names.
   %br
-  Note: If the context for a field you want to enter is not available in the
-  #{link_to 'default schema', annotation_context_path, target: :_blank} then you must provide the full URI for that metadata field.
-
-  #additional_metadata
-
-  .new_metadata_btns{:id => 'new_metadata_btns'}
-    %br
-    = button_tag 'Add Metadata Field', :id =>'add_metadata_btn', type: 'button'
-    = link_to 'Cancel', collections_path
-    = submit_tag 'Create'
+  = link_to 'Cancel', collections_path
+  = submit_tag 'Create'
 
 = render 'shared/nectar_attribution'
-
-:javascript
-  function add_metadata_field(meta_key, meta_value) {
-    var key_field = "<label>Name:</label><input type='text' name='additional_key[]' class='metadata_field' value='"+meta_key+"'/>";
-    var value_field = "<label>Value:</label><input type='text' name='additional_value[]' class='metadata_field' value='"+meta_value+"'/>";
-    $("#additional_metadata").append("<br><div class='metadata_pair'>"+key_field+value_field+"</div>");
-  }
-
-  $("#add_metadata_btn").click(function() {
-    add_metadata_field('', '');
-  });
-
-- @additional_metadata.each do |meta_key, meta_value|
-  - unless meta_key.blank? && meta_value.blank?
-    = javascript_tag "add_metadata_field('#{meta_key}', '#{meta_value}')"

--- a/features/collections_create.feature
+++ b/features/collections_create.feature
@@ -63,8 +63,8 @@ Feature: Creating Collections
     Given I am logged in as "data_owner@intersect.org.au"
     And I am on the create collection page
     When I click "Add Metadata Field"
-    Then I should see "Name:"
-    And I should see "Value:"
+    Then the "additional_key[]" field should contain ""
+    And the "additional_value[]" field should contain ""
 
   @create_collection
   Scenario: Verify creating a collection with just a the required fields
@@ -163,7 +163,7 @@ Feature: Creating Collections
     And I should see "<response>"
   Examples:
     | key | value | response|
-    |     | bar   | An additional metadata field is missing a key      |
+    |     | bar   | An additional metadata field is missing a name     |
     | foo |       | Additional metadata field 'foo' is missing a value |
 
   @create_collection @javascript

--- a/features/item_create.feature
+++ b/features/item_create.feature
@@ -49,27 +49,28 @@ Feature: Creating Items
     And I should see "Item Name:"
     And I should see "Item Title:"
     And I should see "Additional Metadata"
-    And I should see "See searchable fields for suggestions"
+    And I should see "See the RDF Names of searchable fields for examples of accepted metadata field names."
     And I should see link "searchable fields" to "/catalog/searchable_fields"
+    And I should see "Note: If the context for a field you want to enter is not available in the default schema then you must provide the full URI for that metadata field."
+    And I should see link "default schema" to "/schema/json-ld"
     And I should see "Add Metadata Field"
     And I should see button with text "Add Metadata Field"
     And I should see link "Cancel" to "/catalog/cooee"
     And I should see "Create"
     And I should see button "Create"
 
-  Scenario: Verify add metadata key/value fields not visible by default
+  Scenario: Verify add metadata name/value fields not visible by default
     Given I am logged in as "data_owner@intersect.org.au"
     When I am on the add item page for "cooee"
-    Then I should not see "Key:"
-    And I should not see "Value:"
+    Then I should not see "Name: Value: "
 
   @javascript
-  Scenario: Verify add metadata key/value fields are visible after clicking add metadata field button
+  Scenario: Verify add metadata name/value fields are visible after clicking add metadata field button
     Given I am logged in as "data_owner@intersect.org.au"
     And I am on the add item page for "cooee"
     When I click "Add Metadata Field"
-    Then I should see "Key:"
-    And I should see "Value:"
+    Then the "additional_key[]" field should contain ""
+    And the "additional_value[]" field should contain ""
 
   Scenario Outline: Verify item name and title are required
     Given I am logged in as "data_owner@intersect.org.au"
@@ -176,8 +177,26 @@ Feature: Creating Items
     And I fill in "additional_value[]" with "<value>"
     And I press "Create"
     Then I should be on the add item page for "<collection_name>"
-    Then I should see "<response>"
+    And I should see "<response>"
   Examples:
     | collection_name | key | value | response |
-    | test            |     | foo   | An additional metadata field is missing a key      |
+    | test            |     | foo   | An additional metadata field is missing a name     |
     | test            | bar |       | Additional metadata field 'bar' is missing a value |
+
+  @javascript @create_collection
+  Scenario: Verify form is re-populated with previous input if an error occurs
+    Given I ingest a new collection "test" through the api with the API token for "data_owner@intersect.org.au"
+    And I am logged in as "data_owner@intersect.org.au"
+    And I am on the add item page for "test"
+    And I click "Add Metadata Field"
+    When I fill in "item_name" with "test"
+    And I fill in "item_title" with "Test"
+    And I fill in "additional_key[]" with "foo"
+    And I fill in "additional_value[]" with ""
+    And I press "Create"
+    Then I should be on the add item page for "test"
+    And I should see "Additional metadata field 'foo' is missing a value"
+    And the "item_name" field should contain "test"
+    And the "item_title" field should contain "Test"
+    And the "additional_key[]" field should contain "foo"
+    And the "additional_value[]" field should contain ""


### PR DESCRIPTION
Repopulate form fields with previous input when validation failure occurs. Also open link to searchable fields in new tab.