### PR TITLE
Misc: update collection storage location

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -11,7 +11,7 @@ HcsvlabWeb::Application.configure do
   config.user_annotations_location = "/data/contributed_annotations/"
 
   # Base directory where api created collections will be stored
-  config.api_collections_location = "/data/collections/"
+  config.api_collections_location = "/data/production_collections/"
 
   # Settings specified here will take precedence over those in config/application.rb
 

--- a/config/environments/qa.rb
+++ b/config/environments/qa.rb
@@ -12,7 +12,7 @@ HcsvlabWeb::Application.configure do
   config.user_annotations_location = "/data/contributed_annotations/"
 
   # Base directory where api created collections will be stored
-  config.api_collections_location = "/data/collections/"
+  config.api_collections_location = "/data/production_collections/"
 
   # Settings specified here will take precedence over those in config/application.rb
 

--- a/config/environments/qa2.rb
+++ b/config/environments/qa2.rb
@@ -12,7 +12,7 @@ HcsvlabWeb::Application.configure do
   config.user_annotations_location = "/data/contributed_annotations/"
 
   # Base directory where api created collections will be stored
-  config.api_collections_location = "/data/collections/"
+  config.api_collections_location = "/data/production_collections/"
 
   # Settings specified here will take precedence over those in config/application.rb
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -12,7 +12,7 @@ HcsvlabWeb::Application.configure do
   config.user_annotations_location = "/data/contributed_annotations/"
 
   # Base directory where api created collections will be stored
-  config.api_collections_location = "/data/collections/"
+  config.api_collections_location = "/data/production_collections/"
 
   # Settings specified here will take precedence over those in config/application.rb
 

--- a/config/environments/staging2.rb
+++ b/config/environments/staging2.rb
@@ -12,7 +12,7 @@ HcsvlabWeb::Application.configure do
   config.user_annotations_location = "/data/contributed_annotations/"
 
   # Base directory where api created collections will be stored
-  config.api_collections_location = "/data/collections/"
+  config.api_collections_location = "/data/production_collections/"
 
   # Settings specified here will take precedence over those in config/application.rb
 


### PR DESCRIPTION
Update the storage directory for collections created through the API to match the directory used for the manually ingested collections (specified in the deployment guide).