### PR TITLE
HCSVLAB-1121: add more character sanitisation in item name

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -169,6 +169,7 @@ class CollectionsController < ApplicationController
     begin
       request_params = cleanse_params(params)
       collection = validate_collection(request_params[:id], request_params[:api_key])
+      # ToDo: sanitise each item name (dc:identifier) once the new JSON-LD format is completed
       validate_add_items_request(collection, collection.corpus_dir, request_params[:items], request_params[:file])
       request_params[:items].each do |item_json|
         update_ids_in_jsonld(item_json["metadata"], collection)
@@ -191,7 +192,7 @@ class CollectionsController < ApplicationController
     if request.post?
       begin
         validate_required_web_fields(params, {:item_name => 'item name', :item_title => 'item title'})
-        item_name = validate_item_name_unique(collection, params[:item_name])
+        item_name = validate_item_name_unique(collection, Item.sanitise_name(params[:item_name]))
         additional_metadata = validate_item_additional_metadata(params)
         json_ld = construct_item_json_ld(collection, item_name, params[:item_title], additional_metadata)
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -12,7 +12,9 @@ class Item < ActiveRecord::Base
   scope :indexed, where('indexed_at is not null')
 
   def self.sanitise_name(name)
-    name.downcase.delete(' ')
+    # Spaces shouldn't be used since Sesame uses the name within the metadata URI
+    # . and / shouldn't be used in the name since they can break the routes mapping
+    name.downcase.delete(' ./')
   end
 
   def has_primary_text?

--- a/features/item_create.feature
+++ b/features/item_create.feature
@@ -137,6 +137,33 @@ Feature: Creating Items
     | test            | test2       | test2          | Test Spaces  |
     | test            | test3 space | test3space     | Test Spaces  |
 
+  @create_collection
+  Scenario Outline: Verify creating an item sanitises the item name
+    Given I ingest a new collection "test" through the api with the API token for "data_owner@intersect.org.au"
+    And I am logged in as "data_owner@intersect.org.au"
+    And I am on the add item page for "test"
+    And I fill in "item_name" with "<name>"
+    And I fill in "item_title" with "test"
+    And I press "Create"
+    And I reindex all
+    When I go to the catalog page for "test:<sanitised_name>"
+    Then I should see a page with the title: "Alveo - test:<sanitised_name>"
+    And I should see "test:<sanitised_name>"
+    And I should see "This Item has no display document"
+    And I should see "This Item has no documents"
+    And I should see "Item Details"
+    And I should see "Title: test"
+    And I should see "Identifier: <sanitised_name>"
+    And I should see "Collection: test"
+    And I should see "SPARQL endpoint http://www.example.com/sparql/test"
+  Examples:
+    | name             | sanitised_name   |
+    | TESTUPPERCASE    | testuppercase    |
+    | test with spaces | testwithspaces   |
+    | test/with/slash  | testwithslash    |
+    | test.with.period | testwithperiod   |
+    | Test with/allthe/Sanitisations.to be.cleaned | testwithallthesanitisationstobecleaned|
+
   @javascript @create_collection
   Scenario Outline: Create an item with a set of additional metadata
     Given I ingest a new collection "<collection_name>" through the api with the API token for "data_owner@intersect.org.au"

--- a/lib/api/request_validator.rb
+++ b/lib/api/request_validator.rb
@@ -32,8 +32,7 @@ module RequestValidator
 
   # Validates that the given item name is not already in use by an existing item in the given collection
   # Returns a sanitised copy of the item name
-  def validate_item_name_unique(collection, name)
-    item_name = Item.sanitise_name(name)
+  def validate_item_name_unique(collection, item_name)
     if collection.items.find_by_handle("#{collection.name}:#{item_name}").present?
       raise ResponseError.new(400), "An item with the name '#{item_name}' already exists in this collection"
     end


### PR DESCRIPTION
Add sanitisation of '.' and '/' characters in the item name to avoid breaking of the route mappings for an item.
